### PR TITLE
Add some missing escaping

### DIFF
--- a/class.vk-sharing-jetpack.php
+++ b/class.vk-sharing-jetpack.php
@@ -56,16 +56,16 @@ class Share_VKcom extends Share_Twitter {
 					false,
 					{
 						type: "button",
-						url: "'. get_permalink( $post->ID ) .'",
+						url: "'. esc_js( get_permalink( $post->ID ) ) .'",
 						text: ""
 					}
 				)
 			);
 			--></script>';
 		} else if ( $this->icon ) {
-			return '<a target="_blank" rel="nofollow" class="share-vkcom sd-button share-icon" href="http://vk.com/share.php?url='. get_permalink( $post->ID ) .'"><span></span></a>';
+			return '<a target="_blank" rel="nofollow" class="share-vkcom sd-button share-icon" href="http://vk.com/share.php?url='. urlencode( get_permalink( $post->ID ) ) .'"><span></span></a>';
 		} else {
-			return '<a target="_blank" rel="nofollow" class="share-vkcom sd-button share-icon" href="http://vk.com/share.php?url='. get_permalink( $post->ID ) .'"><span>Vk.com</span></a>';
+			return '<a target="_blank" rel="nofollow" class="share-vkcom sd-button share-icon" href="http://vk.com/share.php?url='. urlencode( get_permalink( $post->ID ) ) .'"><span>Vk.com</span></a>';
 		}
 	}
 }


### PR DESCRIPTION
- URLs used in JS should be escaped with `esc_js`
- URLs used as query strings of another URL should be `urlencod`ed
